### PR TITLE
Fix update_bus_info to cope with missing OperatingProfile element

### DIFF
--- a/tfc_web/transport/management/commands/update_bus_info.py
+++ b/tfc_web/transport/management/commands/update_bus_info.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
         traveline_zip_file = zipfile.ZipFile(BytesIO(urlopen('ftp://%s:%s@ftp.tnds.basemap.co.uk/EA.zip' %
                                                              (settings.TNDS_USERNAME, settings.TNDS_PASSWORD)).read()))
         for filename in traveline_zip_file.namelist():
+            logger.info("Processing file %s" % filename)
             with traveline_zip_file.open(filename) as xml_file:
                 content = xmltodict.parse(xml_file)
 
@@ -64,10 +65,11 @@ class Command(BaseCommand):
                         'start_date': service['OperatingPeriod']['StartDate'],
                         'end_date': service['OperatingPeriod']['EndDate'],
                         'regular_days_of_week':
-                            list(service['OperatingProfile']['RegularDayType']['DaysOfWeek'].keys()),
+                            list(service['OperatingProfile']['RegularDayType']['DaysOfWeek'].keys())
+                        if 'OperatingProfile' in service and 'RegularDayType' in service['OperatingProfile'] else ('MondayToFriday',),
                         'bank_holiday_operation':
                             list(service['OperatingProfile']['BankHolidayOperation']['DaysOfNonOperation'].keys())
-                        if 'BankHolidayOperation' in service['OperatingProfile'] else None
+                        if 'OperatingProfile' in service and 'BankHolidayOperation' in service['OperatingProfile'] else None
                     })
 
                     # Routes


### PR DESCRIPTION
OperatingProfile is optional according to the schema and at least one
current timetable file omits it. This patch allows for this and applies
the default (MondayToFriday) if it does.

This patch also adds logging of the file being processed to aid
diagnosing such problems in future.

A test run on tfc-app4 suggests that this patch works!