### PR TITLE
Avoid returning two Journeys

### DIFF
--- a/tfc_web/transport/api/views.py
+++ b/tfc_web/transport/api/views.py
@@ -260,7 +260,8 @@ def siriVM_POST_to_journey(request):
     try:
         for bus in jsondata['request_data']:
             bus['vehicle_journeys'] = \
-                calculate_vehicle_journey(string_to_datetime(bus['OriginAimedDepartureTime']), bus['OriginRef'])
+                calculate_vehicle_journey(string_to_datetime(bus['OriginAimedDepartureTime']), bus['OriginRef'],
+                                          bus['DestinationRef'])
     except Exception as e:
         return Response({"details": "error while processing siriVM data: %s" % e}, status=500)
     return Response(jsondata)
@@ -298,7 +299,8 @@ def siriVM_to_journey(request):
     try:
         for bus in real_time['request_data']:
             bus['vehicle_journeys'] = \
-                calculate_vehicle_journey(string_to_datetime(bus['OriginAimedDepartureTime']), bus['OriginRef'])
+                calculate_vehicle_journey(string_to_datetime(bus['OriginAimedDepartureTime']), bus['OriginRef'],
+                                          bus['DestinationRef'])
             if 'expand_journey' in request.GET and request.GET['expand_journey'] == 'true':
                 bus['vehicle_journeys'] = VehicleJourneySerializer(VehicleJourney.objects.filter(pk__in=bus['vehicle_journeys']), many=True).data
     except:

--- a/tfc_web/transport/api/views.py
+++ b/tfc_web/transport/api/views.py
@@ -44,7 +44,7 @@ def string_to_datetime(str_time):
     return time
 
 
-def calculate_vehicle_journey(departure_time, bus_stop_id):
+def calculate_vehicle_journey(departure_time, departure_stop_id, destination_stop_id=None):
     """
     Retrieves a list of possible Vehicle Journeys from a departure time and a bus stop. Today is always used as
     the day the vehicle operates
@@ -52,9 +52,15 @@ def calculate_vehicle_journey(departure_time, bus_stop_id):
     :param bus_stop:
     :return: list of Vehicle Journeys
     """
-    query1 = Timetable.objects.filter(stop_id=bus_stop_id, time=departure_time.time(), order=1,
-                                      vehicle_journey__days_of_week__contains=departure_time.date().strftime("%A")) \
+    journey_day_of_week = departure_time.date().strftime("%A")
+    query1 = Timetable.objects.filter(stop_id=departure_stop_id, time=departure_time.time(), order=1,
+                                      vehicle_journey__days_of_week__contains=journey_day_of_week) \
         .values_list('vehicle_journey', flat=True)
+    if destination_stop_id:
+        query1b = Timetable.objects.filter(stop_id=destination_stop_id, last_stop=True,
+                                           vehicle_journey__days_of_week__contains=journey_day_of_week) \
+            .values_list('vehicle_journey', flat=True)
+        query1 = query1.union(query1b)
     query2 = VehicleJourney.objects.filter(
         id__in=query1, special_days_operation__days__contains=departure_time.date(),
         special_days_operation__operates=False).values_list('id', flat=True)
@@ -176,6 +182,13 @@ departure_to_journey_schema = ManualSchema(
                         "The datetime or date must be given in ISO 8601 format."
         ),
         coreapi.Field(
+            "destination_stop_id",
+            required=False,
+            location="query",
+            schema=coreschema.String(description="Destination Stop atco_code. Last stop of a Journey."),
+            description="Destination Stop atco_code. Last stop of a Journey."
+        ),
+        coreapi.Field(
             "expand_journey",
             required=False,
             location="query",
@@ -206,8 +219,11 @@ def departure_to_journey(request):
     try:
         departure_stop = Stop.objects.get(atco_code=departure_stop_id)
     except:
-        return Response({"details": "Stop %s not found" % departure_stop_id}, status=404)
-    vj_list = calculate_vehicle_journey(departure_time, departure_stop.atco_code)
+        return Response({"details": "Departure Stop %s not found" % departure_stop_id}, status=404)
+    destination_stop_id = request.GET.get('destination_stop_id', None)
+    if destination_stop_id and not Stop.objects.filter(atco_code=destination_stop_id).exists():
+        return Response({"details": "Destination Stop %s not found" % destination_stop_id}, status=404)
+    vj_list = calculate_vehicle_journey(departure_time, departure_stop.atco_code, destination_stop_id)
     if 'expand_journey' in request.GET and request.GET['expand_journey'] == 'true':
         vj_list = VehicleJourneySerializer(VehicleJourney.objects.filter(pk__in=vj_list), many=True).data
     return Response({'results': vj_list})


### PR DESCRIPTION
There are some rare cases where different buses have the same departure time and stop. In order to avoid returning more than one Journey as a result in the API, this modification allows the user of the API to also include the destination stop. This should avoid returning more than one Journey, as there is (at this moment) no cases where more than bus departs at the same time from the same stop with the same destination.