### PR TITLE
Fix the link to the NRE logo on the Smartpanel /info/ page

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/info.html
+++ b/tfc_web/smartpanel/templates/smartpanel/info.html
@@ -2,6 +2,8 @@
 {% load static %}
 {% block content %}
 
+<h1>SmartPanels</h1>
+
 <p><em>Adaptive Cities</em> <strong>SmartPanels</strong> display travel
 information in the lobbies of public buildings to inform travel
 choices.</p>
@@ -50,7 +52,7 @@ products and services, including:</p>
 
     <li>Train departure information provided by
         <a href="http://www.nationalrail.co.uk/">National Rail Enquiries</a>
-        under a modified Open Government Licence <img src="{% static 'smartpanel/NRE_Logo_powered.png'%}" alt="NRE Logo"/></li>
+        under a modified Open Government Licence <img class="footer-logo" src="{% static 'smartpanel/NRE_Powered_logo.png'%}" alt="NRE Logo"/></li>
 
     <li>Bus timetable and stop details from the 
         <a href="http://www.travelinedata.org.uk/traveline-open-data/traveline-national-dataset/">Traveline National Dataset</a>
@@ -60,7 +62,7 @@ products and services, including:</p>
     <li>Map data from <a href="https://www.openstreetmap.org">OpenStreetMap</a> 
         &copy; OpenStreetMap contributors (see <a href="https://www.openstreetmap.org/copyright">details</a>)</li>
 
-    <li>Icons made by <a href="https://www.flaticon.com/authors/google" title="Google">Google</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></li>
+    <li>Icons made by <a href="https://www.flaticon.com/authors/google" title="Google">Google</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> are licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></li>
 
 </ul>
 


### PR DESCRIPTION
Closes #43