### PR TITLE
Fix widget auto-discovery

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/layout_config.html
+++ b/tfc_web/smartpanel/templates/smartpanel/layout_config.html
@@ -53,11 +53,9 @@
             {% else %}
                 <select id="widget-{{ key }}" class="widget mdl-textfield__input" style="width: 200px;">
                     <option value="" selected disabled>Select a widget</option>
-                    <option value="station_board">Train Stations</option>
-                    <option value="weather">Weather</option>
-                    <option value="traffic_map">Traffic Map</option>
-                    <option value="twitter_timeline">Twitter timeline</option>
-                    <option value="message_area">Message Area</option>
+                    {% for widget in widgets_list %}
+                    <option value="{{ widget.file}}">{{ widget.name }}</option>
+                    {% endfor %}
                 </select>
                 <div class="container-form"></div>
             {% endif %}

--- a/tfc_web/smartpanel/templates/smartpanel/layout_config2.html
+++ b/tfc_web/smartpanel/templates/smartpanel/layout_config2.html
@@ -69,11 +69,9 @@
                             <select id="widget-{{ key }}" class="widget mdl-textfield__input"
                                     style="width: 80%; top: 20px; position: relative; margin-bottom: 10px;">
                                 <option value="" selected disabled>Select a widget</option>
-                                <option value="station_board">Train Stations</option>
-                                <option value="weather">Weather</option>
-                                <option value="traffic_map">Traffic Map</option>
-                                <option value="twitter_timeline">Twitter timeline</option>
-                                <option value="message_area">Message Area</option>
+                                {% for widget in widgets_list %}
+                                <option value="{{ widget.file}}">{{ widget.name }}</option>
+                                {% endfor %}
                             </select>
                             <div class="container-form"></div>
                         {% endif %}

--- a/tfc_web/smartpanel/views/smartpanel.py
+++ b/tfc_web/smartpanel/views/smartpanel.py
@@ -81,11 +81,11 @@ def generate_widget_list():
     list_widget_files = os.listdir(widget_directory)
     list_widgets = []
     for widget_file in list_widget_files:
-        if os.path.isdir(widget_file):
+        if os.path.isdir(os.path.join(settings.BASE_DIR, 'static/smartpanel/widgets', widget_file)):
             list_widgets.append({
                 'name': json.load(open(os.path.join(widget_directory, '%s/%s_schema.json' %
                                                     (widget_file, widget_file))))['title'],
-                'file': list_widgets
+                'file': widget_file
             })
     return list_widgets
 


### PR DESCRIPTION
While it looked as if the framework was auto-discovering widgets, it
turns out:

1) That generate_widget_list() in smartpanel/views/smartpanel.py didn't
work; and

2) smartpanel/templates/smartpanel/layout_config.html and
smartpanel/templates/smartpanel/layout_config2.html had a hard-coded
list and didn't use the supplied value of 'widgets_list'

This patch fixes this.