### PR TITLE
Edit message text in a text area

### DIFF
--- a/tfc_web/static/smartpanel/widgets/message_area/message_area_schema.json
+++ b/tfc_web/static/smartpanel/widgets/message_area/message_area_schema.json
@@ -17,7 +17,8 @@
         "message": {
             "type": "string",
             "title": "Message",
-            "description": "Message text"
+            "description": "Message text",
+            "format": "text"
         }
     }
 }


### PR DESCRIPTION
A hidden feature of brutusin:json-forms is that a string field
with '"format": "text"' will generate a text area for editing.
Use this for editing the message parameter of message_area.

Closes #58