### PR TITLE
Tidy the schema files:

### DIFF
--- a/tfc_web/static/smartpanel/widgets/iframe_area/iframe_area_schema.json
+++ b/tfc_web/static/smartpanel/widgets/iframe_area/iframe_area_schema.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/iframe_area.json",
     "$comment": "",
-    "description": "Parameters for the ACP Iframe Area widget",
+    "description": "Display the content of a selected web page",
     "title": "Iframe Area",
 
     "type": "object",
@@ -12,8 +12,9 @@
         "url": {
             "type": "string",
             "title": "URL",
-            "description": "The URL of the page to enbed",
-            "format": "url"
+            "description": "The URL of the page to display",
+            "format": "uri",
+            "default": "http://people.ds.cam.ac.uk/jw35/"
         },
         "scale": {
             "type": "number",

--- a/tfc_web/static/smartpanel/widgets/message_area/message_area_schema.json
+++ b/tfc_web/static/smartpanel/widgets/message_area/message_area_schema.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/message_area.json",
     "$comment": "Text to embed must be suitable for directly embedding in a <div> container. It must be sanitised to avoid issues such as Cross Site Scripting.",
-    "description": "Parameters for the ACP Iframe Message widget",
+    "description": "Display a text message",
     "title": "Message Area",
 
     "type": "object",
@@ -17,7 +17,7 @@
         "message": {
             "type": "string",
             "title": "Message",
-            "description": "Message text",
+            "description": "Message text, can include simple HTML markup",
             "format": "text"
         }
     }

--- a/tfc_web/static/smartpanel/widgets/station_board/station_board_schema.json
+++ b/tfc_web/static/smartpanel/widgets/station_board/station_board_schema.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/station_board.json",
     "$comment": "A document mapping station names (and other information) to National Rail Enquiry CRS codes is available at http://www.nationalrail.co.uk/static/documents/content/station_codes.csv. While the widget will work with any valid station code there are UI advantages to only displaying (or at least promoting) stations 'local' to the display's location - perhaps just CBG and CMB for Cambridge",
-    "description": "Parameters for the ACP Station Board widget",
+    "description": "Display a train station departure board",
     "title": "Station Board",
 
     "type": "object",
@@ -12,16 +12,20 @@
 
         "station": {
             "type": "string",
+            "enum": ["CBG", "CMB"],
             "title": "Station code",
-            "format": "station_id"
+            "default": "CBG",
+            "description": "National Rail code for the station",
+            "format": "smartpanel:train_station"
         },
 
         "offset": {
             "type": "integer",
             "title": "Timing offset",
-            "description": "Offset in minutes against the current time to provide the station board for",
+            "description": "Offset from now to the start of the timetable (in minutes)",
             "minimum": -120,
-            "maximum": 120
+            "maximum": 120,
+            "default": 0
         }
     }
 }

--- a/tfc_web/static/smartpanel/widgets/stop_bus_map/stop_bus_map.js
+++ b/tfc_web/static/smartpanel/widgets/stop_bus_map/stop_bus_map.js
@@ -109,7 +109,7 @@ function StopBusMap(config, params) {
         map_div.setAttribute('id', config.container+'_map');
         container_el.appendChild(map_div);
 
-        map = L.map(map_div, { zoomControl:false }).setView([params.lat, params.lng], params.zoom);
+        map = L.map(map_div, { zoomControl:false }).setView([params.map.lat, params.map.lng], params.map.zoom);
         map_tiles = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);

--- a/tfc_web/static/smartpanel/widgets/stop_bus_map/stop_bus_map_schema.json
+++ b/tfc_web/static/smartpanel/widgets/stop_bus_map/stop_bus_map_schema.json
@@ -3,75 +3,91 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/stop_busmap.json",
     "$comment": "",
-    "description": "Parameters for the ACP bus stop map widget",
+    "description": "Display a map showing bus stop and live bus positions",
     "title": "Bus stop map",
 
     "type": "object",
-    "required": ["title", "breadcrumbs", "lat", "lng", "zoom", "stops"],
+    "required": ["title", "breadcrumbs", "map", "stops"],
     "properties": {
         "title": {
             "type": "string",
-            "title": "Map title",
-            "description": "Title of the map display",
-            "min": 1.0
+            "title": "Title",
+            "description": "Map title"
         },
         "breadcrumbs": {
             "type": "boolean",
             "title": "Breadcrumbs",
             "description": "Show bus path with breadcrumbs?"
         },
-        "lat": {
-            "type": "number",
-                "title": "Latitude",
-                "description": "Latitude of the centre of the map",
-                "minimum": -90.0,
-                "maximum": 90.0
-        },
-        "lng": {
-            "type": "number",
-            "title": "Longitude",
-            "description": "Longitude of the centre of the map",
-            "minimum": -180,
-            "maximum": 180
-        },
-        "zoom": {
-            "type": "integer",
-            "title": "Map zoom",
-            "description": "Map zoom level",
-            "minimum": 0,
-            "maximum": 21
+        "map": {
+            "type": "object",
+            "title": "Map definition",
+            "format": "smartspanel:lmap",
+            "required": ["lat", "lng", "zoom"],
+            "properties": {
+                "lat": {
+                    "type": "number",
+                        "title": "Latitude",
+                        "description": "Latitude of the centre of the map",
+                        "minimum": -90.0,
+                        "maximum": 90.0,
+                        "default": 52.215
+                },
+                "lng": {
+                    "type": "number",
+                    "title": "Longitude",
+                    "description": "Longitude of the centre of the map",
+                    "minimum": -180,
+                    "maximum": 180,
+                    "default": 0.09
+                },
+                "zoom": {
+                    "type": "integer",
+                    "title": "Map zoom",
+                    "description": "Map zoom level",
+                    "minimum": 0,
+                    "maximum": 21,
+                    "default": 15
+                }
+            }
         },
         "stops": {
             "type": "array",
             "title": "Stops",
+            "description": "Bus stops to show on the map",
             "minItems": 1,
             "items": {
                 "type": "object",
                 "required": ["stop_id", "common_name", "lat", "lng"],
+                "format": "smartpanel:bus_stop",
                 "properties": {
                     "stop_id": {
                         "type": "string",
                         "title": "Stop ID",
-                        "description": "NaPTAN AtcoCode of stop to mark"
+                        "description": "NaPTAN AtcoCode of stop to mark",
+                        "default": "0500CCITY424"
                     },
                     "common_name": {
                         "type": "string",
                         "title": "Stop label",
-                        "description": "Label for stop"
+                        "description": "Label for stop",
+                        "default": "William Gates Building"
                     },
                     "lat": {
                         "type": "number",
                         "title": "Latitude",
-                        "description": "Latitude of the centre of the map",
+                        "description": "Latitude of the bus stop",
                         "minimum": -90.0,
-                        "maximum": 90.0
+                        "maximum": 90.0,
+                        "default": 52.21129
                     },
                     "lng": {
                         "type": "number",
                         "title": "Longitude",
-                        "description": "Longitude of the centre of the map",
+                        "description": "Longitude of the bus stop",
                         "minimum": -180,
-                        "maximum": 180
+                        "maximum": 180,
+                        "default": 0.09107
                     }
                 }
             }

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
@@ -182,7 +182,7 @@ function StopTimetable(config, params) {
         img.setAttribute('src', config.static_url + 'bus.png');
         title.appendChild(img);
         title.appendChild(document.createTextNode(' '));
-        title.appendChild(document.createTextNode(params.common_name));
+        title.appendChild(document.createTextNode(params.title));
         content_area.appendChild(title);
 
         var connection_div = document.createElement('div');

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable_schema.json
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable_schema.json
@@ -2,44 +2,47 @@
 
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/stop_timetable.json",
-    "description": "Parameters for the ACP Stop Timetable widget",
+    "description": "Display a bus timetable",
     "title": "Bus stop timetable",
 
     "type": "object",
-    "required": ["stop_id", "common_name", "layout"],
+    "required": ["stop_id", "title", "layout"],
     "properties": {
+
+        "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "Timetable title"
+        },
 
         "stop_id": {
             "type": "string",
             "title": "Bus stop ID",
-            "description": "The NaPTAN AtcoCode of the stop to display"
-        },
-
-        "common_name": {
-            "type": "string",
-            "title": "Stop name or description",
-            "description": "Used as the title of the timetable display"
+            "description": "The NaPTAN AtcoCode of the stop to display",
+            "format": "smartpanel:bus_stop",
+            "default": "0500CCITY424"
         },
 
         "offset": {
             "type": "integer",
             "title": "Timing offset",
-            "description": "Offset in minutes against the current time to provide the station board for",
+            "description": "Offset from now to the start of the timetable (minutes)",
             "minimum": -120,
-            "maximum": 120
+            "maximum": 120,
+            "default": 0
         },
 
         "layout": {
             "type": "string",
             "title": "Layout",
-            "description": "Required layout for the display",
+            "description": "Display layout",
             "enum": [ "simple", "multiline", "nextbus", "debug" ]
         },
 
         "destinations": {
             "type": "array",
             "title": "Destinations",
-            "description": "Additional destinations to include on the display",
+            "description": "Destinations to include in the timetable",
             "items": {
                 "type": "object",
                 "required": ["description"],
@@ -47,35 +50,39 @@
                     "description": {
                         "type": "string",
                         "title": "Description",
-                        "description": "Description of the destination"
+                        "description": "Description of the destination (e.g. 'City Centre')",
+                        "default": "City Centre"
                     },
                     "stop_ids": {
                         "type": "array",
-                        "title": "Destination bus stop IDs",
+                        "title": "Destination stops",
                         "description": "One or more NaPTAN AtcoCodes of stops making up the destination",
                         "items": {
-                            "type": "string"
+                            "type": "string",
+                            "format": "smartpanel:bus_stop",
+                            "default": "0500CCITY419"
                         }
                     },
                     "area": {
                         "type": "array",
                         "title": "Destination area",
                         "description": "A list of lat/lng coordinate pairs defining the destination area",
+                        "format": "smartpanel:polygon",
                         "items": {
                             "type": "object",
-                            "required": ["lng", "lat"],
+                            "required": ["lat", "lng"],
                             "properties": {
-                                "lng": {
-                                    "type": "number",
-                                    "title": "Longitude",
-                                    "maximum": 180,
-                                    "minumum": -180
-                                },
                                 "lat": {
                                     "type": "number",
                                     "title": "Latitude",
                                     "maximum": 90,
                                     "minimum": -90
+                                },
+                                "lng": {
+                                    "type": "number",
+                                    "title": "Longitude",
+                                    "maximum": 180,
+                                    "minumum": -180
                                 }
                             }
                         }

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable_schema.json
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable_schema.json
@@ -2,6 +2,7 @@
 
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/stop_timetable.json",
+    "$comment": "The 'area' array should ideally have 'minItems: 3' so that the resulting polygon actually has an area. Unfortunately what appears to be a bug in Brutusin Json-Forms (https://github.com/brutusin/json-forms/issues/123) then causes a validation error even if no area is defined. Pending resolution, people will just have to work out for themselves that a two point polygon can have no content.",
     "description": "Display a bus timetable",
     "title": "Bus stop timetable",
 

--- a/tfc_web/static/smartpanel/widgets/traffic_map/traffic_map_schema.json
+++ b/tfc_web/static/smartpanel/widgets/traffic_map/traffic_map_schema.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/traffic.json",
     "$comment": "",
-    "description": "Parameters for the ACP Traffic widget",
+    "description": "Display a map showing traffic speeds",
     "title": "Traffic Map",
 
     "type": "object",
@@ -12,13 +12,16 @@
         "interval": {
             "type": "number",
             "title": "Display interval",
-            "description": "Time in seconds to display each map",
-            "min": 1.0
+            "description": "Time to display each map (seconds)",
+            "min": 1.0,
+            "default": 7.5
         },
         "maps": {
             "type": "array",
             "minItems": 1,
             "title": "Maps",
+            "description": "One or more maps to display in sequence",
+            "format": "smartpanel:gmap",
             "items": {
                 "type": "object",
                 "required": ["lat", "lng", "zoom"],
@@ -28,21 +31,24 @@
                         "title": "Latitude",
                         "description": "Latitude of the centre of the map",
                         "minimum": -90.0,
-                        "maximum": 90.0
+                        "maximum": 90.0,
+                        "default": 52.204
                     },
                     "lng": {
                         "type": "number",
                         "title": "Longitude",
                         "description": "Longitude of the centre of the map",
                         "minimum": -180,
-                        "maximum": 180
+                        "maximum": 180,
+                        "default": 0.124
                     },
                     "zoom": {
                         "type": "integer",
                         "title": "Map zoom",
                         "description": "Map zoom level",
                         "minimum": 0,
-                        "maximum": 21
+                        "maximum": 21,
+                        "default": 12
                     }
                 }
             }

--- a/tfc_web/static/smartpanel/widgets/twitter_timeline/twitter_timeline_schema.json
+++ b/tfc_web/static/smartpanel/widgets/twitter_timeline/twitter_timeline_schema.json
@@ -3,7 +3,7 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://smartcambridge.org/schemas/widgets/twitter_timeline.json",
     "$comment": "",
-    "description": "Parameters for the ACP Twitter Timeline widget",
+    "description": "Display the timeline from a selected Twitter account",
     "title": "Twitter Timeline",
 
     "type": "object",
@@ -12,7 +12,8 @@
         "who": {
             "type": "string",
             "title": "Twitter ID",
-            "description": "Twitter ID (without leading '@') of the timeline to display"
+            "description": "Twitter ID (without leading '@') of a timeline to display",
+            "default": "Cambs_Traffic"
         }
     }
 }

--- a/tfc_web/static/smartpanel/widgets/weather/weather_schema.json
+++ b/tfc_web/static/smartpanel/widgets/weather/weather_schema.json
@@ -4,7 +4,7 @@
     "$id": "http://smartcambridge.org/schemas/widgets/weather.json",
     "$comment": "Information mapping places onto 'location' codes for the 3 hour forecast can be retrieved from the forecast site list feed -- see https://www.metoffice.gov.uk/datapoint/support/documentation/uk-locations-site-list-detailed-documentation. While the widget will work with any valid location there are UI advantages to only displaying (or at least promoting) places 'local' to the display's position",
     "title": "Weather",
-    "description": "Parameters for the ACP Weather widget",
+    "description": "Display a weather forecast",
 
     "type": "object",
     "required": ["location"],
@@ -14,7 +14,8 @@
             "type": "string",
             "title": "Location code",
             "description": "Met Office 3 hour forecast location code",
-            "format": "forecast_location"
+            "format": "smartpanel:forecast_location",
+            "default": "310042"
         }
 
     }


### PR DESCRIPTION
1. Always ask for lat/lng in that order

2. Re-word various titles and descriptions

3. Request codes in 'enum's where appropriate

4. Add useful defaults where appropriate (having observed that defaults usefully pre-populate form fields)

5. Add experimental support for "smartpanel:*" format specifications

Isolating map definitions into a self-contained object (so that we can apply "format" to it) results in a change to the structure of the parameters passed to the stop_busmap widget and so some minor changes within it.

Closes #72 