### PR TITLE
Jw35 fix station board weather

### DIFF
--- a/tfc_web/smartpanel/views/widgets/station_board.py
+++ b/tfc_web/smartpanel/views/widgets/station_board.py
@@ -51,15 +51,16 @@ def station_board(request):
         if len(data['messages']) > 1:
             data['messages'] = ['Multiple travel alerts in force - see www.nationalrail.co.uk for details.']
 
-        for service in raw_data['trainServices']['service']:
-            this_service = {}
-            this_service['std'] = service['std']
-            this_service['etd'] = service['etd']
-            dest = service['destination']['location'][0]['locationName']
-            if dest in STATION_ABBREV:
-                dest = STATION_ABBREV[dest]
-            this_service['destination'] = dest
-            data['services'].append(this_service)
+        if raw_data['trainServices']:
+            for service in raw_data['trainServices']['service']:
+                this_service = {}
+                this_service['std'] = service['std']
+                this_service['etd'] = service['etd']
+                dest = service['destination']['location'][0]['locationName']
+                if dest in STATION_ABBREV:
+                    dest = STATION_ABBREV[dest]
+                this_service['destination'] = dest
+                data['services'].append(this_service)
 
         cache.set(cache_key, data, timeout=30)
 

--- a/tfc_web/smartpanel/views/widgets/station_board.py
+++ b/tfc_web/smartpanel/views/widgets/station_board.py
@@ -25,7 +25,7 @@ def station_board(request):
     assert station, 'No station code found'
     offset = int(request.GET.get('offset', 0))
 
-    cache_key = "station_board!{0} {1}".format(station, offset)
+    cache_key = "station_board!{0}!{1}".format(station, offset)
     data = cache.get(cache_key)
     if data:
         logger.info('Cache hit for %s', cache_key)

--- a/tfc_web/smartpanel/views/widgets/weather.py
+++ b/tfc_web/smartpanel/views/widgets/weather.py
@@ -265,7 +265,7 @@ def weather(request):
     for result in results:
         result['timestamp_text'] = result['timestamp'].astimezone(tz=None).strftime('%H:%M')
     issued = iso8601.parse_date(data["SiteRep"]["DV"]["dataDate"]).astimezone(tz=None).strftime("%H:%M")
-    logger.info(results)
+    logger.debug(results)
     return render(request, 'smartpanel/weather.html', {
         "results": results,
         "location": data["SiteRep"]["DV"]["Location"]["name"].title(),


### PR DESCRIPTION
Minor fixes to station_board and weather views:

* Code didn't allow for the possibility of a response containing no train
services. Fixes #88.
* Remove space from cache key. Apparently spaces a problematic if the Django cache framework is used with memcached. Even without memcached this results in repeated warnings in the logs. Replace remaining ' ' with '!'.  Fixes #87
* Reduce logging of raw weather data to DEBUG. Helps with #89 