### PR TITLE
Convert internal URL references to absolute

### DIFF
--- a/tfc_web/static/smartpanel/widgets/station_board/station_board.js
+++ b/tfc_web/static/smartpanel/widgets/station_board/station_board.js
@@ -32,7 +32,7 @@ function StationBoard(config, params) {
     this.do_load = function () {
         this.log("Running StationBoard.do_load", this.container);
         var self = this;
-        var url = "../../station_board?station=" + this.params.station;
+        var url = "/smartpanel/station_board?station=" + this.params.station;
         if (this.params.offset) {
             url += "&offset=" + this.params.offset;
         }

--- a/tfc_web/static/smartpanel/widgets/weather/weather.js
+++ b/tfc_web/static/smartpanel/widgets/weather/weather.js
@@ -32,7 +32,7 @@ function Weather(config, params) {
     this.do_load = function () {
         this.log('Running Weather.do_load', this.container);
         var self = this,
-            url = '../../weather?location=' + this.params.location +
+            url = '/smartpanel/weather?location=' + this.params.location +
                 ' .content_area';
         this.log('do_load URI', url);
         this.log('Container', '#' + this.container);


### PR DESCRIPTION
This fixes a problem displaying these widgets on the configuration
screen.

Helps with (closes?) #81