### PR TITLE
Add some default Django logging

### DIFF
--- a/tfc_web/tfc_web/settings.py
+++ b/tfc_web/tfc_web/settings.py
@@ -217,3 +217,28 @@ TNDS_ZONES = ['EA', 'SE', 'EM']
 
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+# An attempt to adapt the default Django logging to log useful stuff
+# in development and production to the console (which will be captured
+# and logged by Gunicorn)
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'detail': {
+            'format': '[%(asctime)s] [%(name)s] [%(levelname)s] - %(message)s',
+            'datefmt': '',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'detail',
+        }
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    }
+}


### PR DESCRIPTION
In production (with DEBUG = False), Django only logs django.server
messages to the console and relies on django.utils.log.AdminEmailHandler
for everythign else. But since we haven't set ADMINS that doesn't do
anything, leaving us deaf/blind.

This patch attempts to modify Django's default log configuration (see
https://docs.djangoproject.com/en/2.0/topics/logging/#disabling-logging-configuration)
to enable console logging even when DEBUG = True *and* to log messages
from everything, not just Django modules.

It's seems to work, but may not be optimal. Suggestions welcome.

Helps with #18