### PR TITLE
Further isolate CSS rules in widgets.css; Rationalise stop_timetable.j

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/station_board.html
+++ b/tfc_web/smartpanel/templates/smartpanel/station_board.html
@@ -28,7 +28,7 @@
     <div class="message">{{ message }}</div>
 {% endfor %}
 
-<table>
+<table class="timetable">
   <tr>
     <th class="time">Due</th>
     <th class="time">Expected</th>

--- a/tfc_web/static/smartpanel/smartpanel.css
+++ b/tfc_web/static/smartpanel/smartpanel.css
@@ -101,6 +101,10 @@
     height: 35px;
 }
 
+.logos {
+  font-family: Arial, sans-serif;
+}
+
 .logos img {
     height: 50px;
     margin: 5px;

--- a/tfc_web/static/smartpanel/widgets.css
+++ b/tfc_web/static/smartpanel/widgets.css
@@ -10,7 +10,7 @@
   box-sizing: border-box;
 }
 
-body {
+.widget {
   font-family: Arial, sans-serif;
 }
 
@@ -32,25 +32,25 @@ body {
     list-style-type: circle;
 }
 .widget ul ul, .widget ul ol, .widget ol ul, .widget ol ol {
-    margin-top: 0;
     margin-bottom: 0;
+    margin-top: 0;
 }
 .widget li {
     border: none;
     position: relative;
 }
 
-h1, h2 {
+.widget h1, .widget h2 {
     margin-bottom: 0;
     margin-top: 0;
 }
 
-h1 img {
+.widget h1 img {
     height: 0.8em;
 }
 
 /* Translucent box to left for labelling maps */
-h1.translucent {
+.widget h1.translucent {
     background-color: white;
     background-color: rgba(255, 255, 255, 0.7);
     color: black;
@@ -60,7 +60,7 @@ h1.translucent {
     top: 0;
 }
 
-table {
+.widget table.timetable {
     border-collapse: collapse;
     margin-left: auto;
     margin-right: auto;
@@ -68,14 +68,14 @@ table {
     overflow: hidden;
 }
 
-th, td {
+.widget .timetable th, .widget .timetable td {
     border-bottom: 1px solid #ddd;
     padding: 0.2rem;
     text-align: left;
     vertical-align: top;
 }
 
-td {
+.widget .timetable td {
     padding: 0.4rem 0.2rem 0.736px 0.2rem;
 }
 
@@ -83,7 +83,7 @@ td {
 /* The relative offset is a hack to get the content to */
 /* appear to align correctly with it's smaller-sized   */
 /* neighbours. Set by eye */
-th.key, td.key {
+.widget th.key, .widget td.key {
     font-size: 1.4rem;
     font-weight: normal;
     position: relative;
@@ -94,39 +94,39 @@ th.key, td.key {
 
 /* .timestamp for 'Last updated hh:mm', etc. */
 
-.timestamp {
+.widget .timestamp {
     font-size: 1.2em;
     font-weight: bold;
 }
 
 /* .message for 'message of the day' boxes, etc */
 
-.message {
+.widget .message {
     background-color: #fdd;
     margin-bottom: 0.5em;
     margin-top: 0.5em;
     padding: 0.5em;
 }
 
-.message p {
+.widget .message p {
     margin: 0;
 }
 
 /* .time for table cells containing HH:MM times */
 
-th.time, td.time {
+.widget th.time, .widget td.time {
     text-align: center;
 }
 
 /* .issue for highlighting things with issues, like late trains */
 
-.issue {
+.widget .issue {
     background-color: #fdd;
 }
 
 /* .widget_error for 'connection problems' banner */
 
-.widget_error {
+.widget .widget_error {
     background: red;
     color: white;
     display: none;

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
@@ -753,7 +753,7 @@ function StopTimetable(config, params) {
             return div;
         }
 
-        return display_multiline_render_dom(rows);
+        return display_multiline_render(rows);
 
     }
 
@@ -848,9 +848,7 @@ function StopTimetable(config, params) {
     }
 
 
-    function display_multiline_render_dom(rows) {
-
-//<table class="multiline">
+    function display_multiline_render(rows) {
 
         var table = document.createElement('table');
         table.classList.add('timetable');
@@ -858,18 +856,16 @@ function StopTimetable(config, params) {
 
         var tr, td;
 
-//{{#each rows}}
+        // For each row in the result set
         for (var r = 0; r < rows.length; r++) {
             var row = rows[r];
-//  <tbody>
             var tbody = document.createElement('tbody');
             table.appendChild(tbody);
 
-//    <tr>
+            // Build the top row
             tr = document.createElement('tr');
             tbody.appendChild(tr);
 
-//      <td rowspan="3" class="expected">{{this.due}}</td>
             td = document.createElement('td');
             tr.appendChild(td);
             td.classList.add('expected');
@@ -877,19 +873,16 @@ function StopTimetable(config, params) {
             td.setAttribute('rowspan', row.rows);
             td.textContent = row.due;
 
-//      <td rowspan="3" class="line">{{this.line}}</td>
             td = document.createElement('td');
             tr.appendChild(td);
             td.classList.add('line');
             td.setAttribute('rowspan', row.rows);
             td.textContent = row.line;
 
-//      <td>to</td>
             td = document.createElement('td');
             tr.appendChild(td);
             td.textContent = 'to';
 
-//      <td>{{this.destination.desc}} <span class="together">(at {{this.destination.time}})</span></td>
             td = document.createElement('td');
             tr.appendChild(td);
             td.textContent = row.destination.desc + ' ';
@@ -898,11 +891,6 @@ function StopTimetable(config, params) {
             span.classList.add('together');
             span.textContent = '(' + row.destination.time +')';
 
-//      {{#if realtime}}
-//      <td rowspan="3"><img src="{{../config.static_url}}/clock-with-white-face.png" alt="" /></td>
-//      {{else}}
-//      <td rowspan="3"><img src="{{../config.static_url}}/timetable-outline.png" alt="" /></td>
-//      {{/if}}
             var url;
             if (row.realtime) {
                 url = config.static_url + '/images/signal6.gif';
@@ -919,50 +907,35 @@ function StopTimetable(config, params) {
             img.setAttribute('src', url);
             img.setAttribute('alt', '');
 
-//    </tr>
-//    <tr class="via">
-//      {{#if via}}
+            // Build the 'via' row if needed
             if (row.via && row.via.length > 0) {
                 tr = document.createElement('tr');
                 tbody.appendChild(tr);
                 tr.classList.add('via');
 
-//      <td>via</td>
                 td = document.createElement('td');
                 tr.appendChild(td);
                 td.textContent = 'via';
 
-//      <td colspan="1">
                 td = document.createElement('td');
                 tr.appendChild(td);
 
-//      {{#each via}}
                 var text = '';
                 for (var v = 0; v < row.via.length; v++) {
                     var via = row.via[v];
-
-//      {{this.desc}} ({{this.time}}){{#unless @last}}, {{/unless}}
                     if (v > 0) {
                         text = text + ', ';
                     }
                     text = text + via.desc + ' (' + via.time + ')';
-//      {{/each}}
                 }
                 td.textContent = text;
-//      </td>
-//      {{/if}}
             }
-//    </tr>
-//    <tr class="timing">
+
+            // Build the 'delay' row if needed
             if (row.delay.text) {
                 tr = document.createElement('tr');
                 tbody.appendChild(tr);
                 tr.classList.add('timing');
-//    {{#if this.delay.mark}}
-//      <td colspan="3" class="issue">{{this.delay.text}}</td>
-//    {{else}}
-//      <td colspan="3">{{this.delay.text}}</td>
-//    {{/if}}
                 td = document.createElement('td');
                 tr.appendChild(td);
                 td.setAttribute('colspan', '3');
@@ -970,12 +943,8 @@ function StopTimetable(config, params) {
                     td.classList.add('issue');
                 }
                 td.textContent = row.delay.text;
-//    </tr>
-///  </tbody>
             }
         }
-//  {{/each}}
-//</table>
 
         return table;
 

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
@@ -614,6 +614,7 @@ function StopTimetable(config, params) {
         //log('display_simple - running');
 
         var table = document.createElement('table');
+        table.classList.add('timetable');
         table.classList.add('simple');
         var heading = document.createElement('tr');
         var cell;
@@ -852,6 +853,7 @@ function StopTimetable(config, params) {
 //<table class="multiline">
 
         var table = document.createElement('table');
+        table.classList.add('timetable');
         table.classList.add('multiline');
 
         var tr, td;
@@ -987,6 +989,7 @@ function StopTimetable(config, params) {
         //log('display_debug - running');
 
         var table = document.createElement('table');
+        table.classList.add('timetable');
         var heading = document.createElement('tr');
         var cell;
 
@@ -1181,6 +1184,7 @@ function StopTimetable(config, params) {
             result.appendChild(h3);
 
             var table = document.createElement('table');
+            table.classList.add('timetable');
             table.appendChild(heading.cloneNode(true));
 
             // ...for each journey...


### PR DESCRIPTION
widgets.css was unconditionally redefining h1, h2 and table which was
problematic for display of non-widget information on pages that included
widgets.css. Isolate those definitions so they only apply within
objects with the .widget class.

Further-further isolate the table definitions, which apply only
to timetables, to a .timetables class and add this as needed to
station_board.html and stop_timetable.js.

Add a knock-on change to smartpanel.css to re-establish
the font definition on the logo/credit header which was previously
'leaking' from widgets.css.

Rename display_multiline_render_dom as display_multiline_render
following the removal of display_multiline_render_moustache.

Remove a collection of outdated comments left over from the conversion
from moustache, replacing some with more useful generic descriptions.

Closes #105 