### PR TITLE
 Rework styling in layout.css, separate from smartpanel.css

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/layout.html
+++ b/tfc_web/smartpanel/templates/smartpanel/layout.html
@@ -2,16 +2,19 @@
 {% load remove_underscore %}
 {% load jsonify %}
 <!DOCTYPE html>
+
 <html>
+
 <head>
+
     <title>SmartCambridge SmartPanel</title>
     <link rel="stylesheet" href="{% static 'smartpanel/layout.css' %}"/>
     <link rel="stylesheet" href="{% static 'smartpanel/widgets.css' %}"/>
     {% for stylesheet in external_stylesheets %}
-        <link rel="stylesheet" href="{{ stylesheet.href }}"{% if stylesheet.integrity %} integrity="{{ stylesheet.integrity }}"  crossorigin="anonymous"{% endif %}>
+        <link rel="stylesheet" href="{{ stylesheet.href }}"{% if stylesheet.integrity %} integrity="{{ stylesheet.integrity }}"  crossorigin="anonymous"{% endif %}/>
     {% endfor %}
     {% for stylesheet in stylesheets %}
-        <link rel="stylesheet" href="{{ stylesheet }}">
+        <link rel="stylesheet" href="{{ stylesheet }}"/>
     {% endfor %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js" integrity="sha256-KWJavOowudybFMUCd547Wvd/u8vUg/2g0uSWYU5Ae+w=" crossorigin="anonymous"></script>
@@ -22,26 +25,33 @@
     {% for script in scripts %}
         <script src="{{ script }}"></script>
     {% endfor %}
+
 </head>
-<body>
-    <div class="logos" style="height: 60px; width: {{display_width|default:"1920px"}}; position: relative;">
-        <div id="screen_clock"></div>
+
+<body class="layout">
+
+    <div class="logos" style="height: 60px; width: {{display_width|default:"1920px"}}">
+        <div id="screen_clock" class="screen_clock"></div>
         <a href="http://www.connectingcambridgeshire.co.uk/smartcamb/"><img alt="Connecting Cambridgshire" src="{% static 'images/logo_sc_112.png' %}"></a>
         <a href="http://www.cam.ac.uk"><img alt="The University of Cambridge" src="{% static 'images/logo_uc_112.png' %}"></a>
         <a href="https://www.greatercambridge.org.uk/"><img alt="Greater Cambridge Partnership" src="{% static 'images/logo_gcp_112.png' %}"></a>
         <span>SmartPanel</span>
     </div>
-    <div class="grid-container mdl-color--teal-900" style="height: calc(({{display_width|default:"1920px"}} * 0.5625) - 60px); width: {{display_width|default:"1920px"}}; overflow: hidden;">
-        <ul id="grid" class="grid">
+
+    <div class="grid_container" style="height: calc(({{display_width|default:"1920px"}} * 0.5625) - 60px); width: {{display_width|default:"1920px"}}">
+        <div class="grid">
             {% for key, value in confdata.items %}
-                <li style="height: calc({{ value.design.h }}*100%/4);
+                <div class="grid-item" style="height: calc({{ value.design.h }}*100%/4);
                         width: calc({{ value.design.w }}*100%/6); top: calc({{ value.design.y }}*100%/4);
                         left: calc({{ value.design.x }}*100%/6);">
-                    <div id="widget-{{ key }}" class="widget {{ value.configuration.widget }}" style="height: 100%; width: 100%; background-color: white; overflow: hidden; position: relative">
-                        {% if not value.configuration %}unconfigured{% endif %}</div></li>
+                    <div id="widget-{{ key }}" class="widget {{ value.configuration.widget }}">
+                        {% if not value.configuration %}unconfigured{% endif %}
+                    </div>
+                </div>
             {% endfor %}
-        </ul>
+        </div>
     </div>
+
     <script>
         // Note we must instatiate RTMonitorAPI before widgets
         var RTMONITOR_API = new RTMonitorAPI();
@@ -101,5 +111,7 @@
             {% endif %}
         });
     </script>
+
 </body>
+
 </html>

--- a/tfc_web/smartpanel/templates/smartpanel/layout.html
+++ b/tfc_web/smartpanel/templates/smartpanel/layout.html
@@ -5,7 +5,7 @@
 <html>
 <head>
     <title>SmartCambridge SmartPanel</title>
-    <link rel="stylesheet" href="{% static 'smartpanel/smartpanel.css' %}"/>
+    <link rel="stylesheet" href="{% static 'smartpanel/layout.css' %}"/>
     <link rel="stylesheet" href="{% static 'smartpanel/widgets.css' %}"/>
     {% for stylesheet in external_stylesheets %}
         <link rel="stylesheet" href="{{ stylesheet.href }}"{% if stylesheet.integrity %} integrity="{{ stylesheet.integrity }}"  crossorigin="anonymous"{% endif %}>

--- a/tfc_web/static/smartpanel/layout.css
+++ b/tfc_web/static/smartpanel/layout.css
@@ -1,131 +1,59 @@
-* {
-    margin: 0;
-    padding: 0;
+/* CSS styles for the mail widget display, layout.css
+*/
+
+/* Force box-sizing: border-box everywhere. Note that this may break
+   some 3rd-party styling in which case it may need to be forced back to
+   content-box there */
+.layout *, .layout *:before, .layout *:after {
+  -webkit-box-sizing: border-box; 
+  -moz-box-sizing: border-box; 
+  box-sizing: border-box;
 }
 
-.inner-box {
-    font-size: 60px;
-    text-align: center;
-    line-height: 60px;
-}
-
-.grid {
-    position: relative;
-    height: 100%;
-    list-style: none;
-    /* Will be modified by the grid jquery lib, depending on the items */
-    -webkit-transition: width 0.1s,
-        height 0.1s;
-    transition: width 0.1s,
-        height 0.1s;
-}
-
-.grid li {
-    position: absolute;
-    border: 1px solid black;
-    /*
-    z-index: 1;
-    font-weight: bold;
-    line-height: 4em;
-    text-align: center;
-    cursor: pointer;
-    box-sizing: border-box;
-    -webkit-transition: top 0.1s,
-        left 0.1s,
-        width 0.1s,
-        height 0.1s,
-        font-size 0.1s,
-        line-height 0.1s;
-    transition: top 0.1s,
-        left 0.1s,
-        width 0.1s,
-        height 0.1s,
-        font-size 0.1s,
-        line-height 0.1s;
-    */
-}
-
-.grid li .inner {
-    height: 100%;
-    background: #fff;
-    -webkit-transition: background 2s;
-    transition: background 2s;
-}
-
-.grid li.ui-draggable-dragging {
-    -webkit-transition: none;
-    transition: none;
-}
-
-.grid li.position-highlight {
-    -webkit-transition: none;
-    transition: none;
-}
-
-.grid li.position-highlight .inner {
-    border: none;
-    background: #ccc;
-}
-
-.grid .controls {
-    position: absolute;
-    top: 0;
-    right: 0;
-    float: right;
-    font-size: 1em;
-    font-weight: normal;
-    opacity: 0;
-    -webkit-transition: opacity 0.2s;
-    transition: opacity 0.2s;
-}
-
-.grid .controls .resize, .grid .controls .delete {
-    font-size: 0.5em;
-    float: left;
-    margin: 5px 5px 0 0;
-    padding: 0.1em;
-    background: #fafafa;
-    color: #444;
-    text-decoration: none;
-}
-
-.grid li:hover .controls {
-    opacity: 1;
-}
-
-.grid .controls .selected {
-    border-color: black;
-    border-width: 2px;
-    border-style: solid;
-    margin: 4px 4px 0 0;
-    height: 35px;
-}
-
-.logos {
+.layout .logos {
   font-family: Arial, sans-serif;
+  left: 0;
+  position: absolute;
+  top: 0;
 }
 
-.logos img {
+.layout .logos img {
     height: 50px;
     margin: 5px;
     padding: 0 0.5em;
 }
 
-.logos span {
-    font-weight: bold;
+.layout .logos span {
     font-size: 50px;
+    font-weight: bold;
+    line-height: 60px;
     position: absolute;
     right: 0.5em;
-    line-height: 60px;
 }
 
-#screen_clock {
+.layout .screen_clock {
     display: inline-block;
     font-size: 50px;
-    line-height: 60px;
     font-weight: bold;
-    width: 200px;
     height: 50px;
+    line-height: 60px;
     margin-left: 20px;
     vertical-align: top;
+    width: 200px;
+}
+
+.layout .grid_container {
+    left: 0;
+    position: absolute;
+    top: 60px;
+}
+
+.layout .grid {
+    height: 100%;
+    position: relative;
+}
+
+.layout .grid > div {
+    border: 1px solid black;
+    position: absolute;
 }

--- a/tfc_web/static/smartpanel/layout.css
+++ b/tfc_web/static/smartpanel/layout.css
@@ -1,0 +1,131 @@
+* {
+    margin: 0;
+    padding: 0;
+}
+
+.inner-box {
+    font-size: 60px;
+    text-align: center;
+    line-height: 60px;
+}
+
+.grid {
+    position: relative;
+    height: 100%;
+    list-style: none;
+    /* Will be modified by the grid jquery lib, depending on the items */
+    -webkit-transition: width 0.1s,
+        height 0.1s;
+    transition: width 0.1s,
+        height 0.1s;
+}
+
+.grid li {
+    position: absolute;
+    border: 1px solid black;
+    /*
+    z-index: 1;
+    font-weight: bold;
+    line-height: 4em;
+    text-align: center;
+    cursor: pointer;
+    box-sizing: border-box;
+    -webkit-transition: top 0.1s,
+        left 0.1s,
+        width 0.1s,
+        height 0.1s,
+        font-size 0.1s,
+        line-height 0.1s;
+    transition: top 0.1s,
+        left 0.1s,
+        width 0.1s,
+        height 0.1s,
+        font-size 0.1s,
+        line-height 0.1s;
+    */
+}
+
+.grid li .inner {
+    height: 100%;
+    background: #fff;
+    -webkit-transition: background 2s;
+    transition: background 2s;
+}
+
+.grid li.ui-draggable-dragging {
+    -webkit-transition: none;
+    transition: none;
+}
+
+.grid li.position-highlight {
+    -webkit-transition: none;
+    transition: none;
+}
+
+.grid li.position-highlight .inner {
+    border: none;
+    background: #ccc;
+}
+
+.grid .controls {
+    position: absolute;
+    top: 0;
+    right: 0;
+    float: right;
+    font-size: 1em;
+    font-weight: normal;
+    opacity: 0;
+    -webkit-transition: opacity 0.2s;
+    transition: opacity 0.2s;
+}
+
+.grid .controls .resize, .grid .controls .delete {
+    font-size: 0.5em;
+    float: left;
+    margin: 5px 5px 0 0;
+    padding: 0.1em;
+    background: #fafafa;
+    color: #444;
+    text-decoration: none;
+}
+
+.grid li:hover .controls {
+    opacity: 1;
+}
+
+.grid .controls .selected {
+    border-color: black;
+    border-width: 2px;
+    border-style: solid;
+    margin: 4px 4px 0 0;
+    height: 35px;
+}
+
+.logos {
+  font-family: Arial, sans-serif;
+}
+
+.logos img {
+    height: 50px;
+    margin: 5px;
+    padding: 0 0.5em;
+}
+
+.logos span {
+    font-weight: bold;
+    font-size: 50px;
+    position: absolute;
+    right: 0.5em;
+    line-height: 60px;
+}
+
+#screen_clock {
+    display: inline-block;
+    font-size: 50px;
+    line-height: 60px;
+    font-weight: bold;
+    width: 200px;
+    height: 50px;
+    margin-left: 20px;
+    vertical-align: top;
+}

--- a/tfc_web/static/smartpanel/widgets.css
+++ b/tfc_web/static/smartpanel/widgets.css
@@ -1,43 +1,13 @@
 /* =================================================================== */
-/* General styling for widget display
-
-/* Force box-sizing: border-box everywhere. Note that this may break
-   some 3rd-party styling in which case it may need to be forced back to
-   content-box there */
-*, *:before, *:after {
-  -webkit-box-sizing: border-box; 
-  -moz-box-sizing: border-box; 
-  box-sizing: border-box;
-}
+/* General styling for widget display                                  */
 
 .widget {
+  background-color: white;
   font-family: Arial, sans-serif;
-}
-
-/* Restore a top/bottom margin around block-level elements */
-/* (removed by smartpanel.css) */
-.widget p, .widget ul, .widget ol, .widget pre, .widget address,
-.widget blockquot, .widget hr {
-    margin: 0.5rem 0;
-}
-
-/* Restore ul/ol/li functionality (removed by smartpanel.css) */
-.widget ul, .widget ol {
-    padding-left: 40px;
-}
-.widget ul {
-    list-style-type: disc;
-}
-.widget ul ul, .widget ol ul {
-    list-style-type: circle;
-}
-.widget ul ul, .widget ul ol, .widget ol ul, .widget ol ol {
-    margin-bottom: 0;
-    margin-top: 0;
-}
-.widget li {
-    border: none;
-    position: relative;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
 }
 
 .widget h1, .widget h2 {


### PR DESCRIPTION
This pull-request represents an experiment. I believe the result is worthwhile, but may have implications that I haven't thought of. Comments, even negative ones, would be welcome.

This version of tfc_web is currently running on 
tfc-app4, in particular serving http://tfc-app4.cl.cam.ac.uk/smartpanel/layout/1/

Change summary:

Seperate layout.html from layout_config.html. Initailly by 
making it depend on a seperate css file, layout.css, which started as a
copy of smartpanel.css.

In layout.html, switch the grid layout to using nested \<div\>s rather
then \<ol\>/\<li\> and limit in-line CSS to things we want to template
effecting size and/or position. Arrange that it has fewer implications
for the styling of the widgets themselves, remove global suppression of
margin/border, etc. Add 'class="layout"' to the body tag.

In layout.css, adapt styling copied over from smartpanel.css to match
the changes above and remove unreferenced rules ans unnecessary styling.
USe absolute positioning to locate the logo and grid container divs to
avoid the need to globally set margins and padding to 0. All layout.css
selectors are prefixed by .layout. This essentially namespace-
qualifies all the class names to make it easier to use layout.css
with other css without name clashes.

In widgets.css, remove the rules that were only there to undo changes
applied by smartpanel.css, and move the global reset of box-model
styling into layout.css where it belongs.