### PR TITLE
Add bounding-box filtering and ordering to /transport/api/stops/

### DIFF
--- a/tfc_web/transport/api/views.py
+++ b/tfc_web/transport/api/views.py
@@ -351,7 +351,7 @@ class StopList(generics.ListAPIView):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = Stop.objects.all()
+        queryset = Stop.objects.all().order_by('atco_code')
         bbox = self.request.query_params.get('bbox', None)
         if bbox is not None:
             match = re.match(r'^(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)$', bbox)


### PR DESCRIPTION
This is an attempt to add bounding-box filtering to /transport/api/stops/ to address the problem identified in #115. There may well be a better way to do this, in which please give me some ideas.

There are (at least) two outstanding problems that I need advice on fixing:

1) How do I get the automatic documentation to report the existence of the bbox parameter (assuming a parameter is the way to go)?
2) Using `raise Http404` to abort the request if the bbox format is incorrect is clearly wrong, but what should I do in it's place? 400 with a suitable result body would be better, but how?