### PR TITLE
Experiment for a lightweight parking data API

### DIFF
--- a/tfc_web/parking/views.py
+++ b/tfc_web/parking/views.py
@@ -4,7 +4,11 @@ from datetime import date, timedelta, datetime
 from urllib.request import urlopen
 from django.conf import settings
 from django.shortcuts import render
+from django.http import JsonResponse
+import re
+import logging
 
+logger = logging.getLogger(__name__)
 
 #############################################################################
 ########   parking/plot/<parking_id>?date=YYYY-MM-DD  #######################
@@ -61,14 +65,19 @@ def parking_plot(request, parking_id):
     MM   = user_date[5:7]
     DD   = user_date[8:10]
 
-    return render(request, 'parking/parking_plot.html', {
-        'config_date':  user_date,
-        'config_parking_id': parking_id,
-        'config_YYYY' : YYYY,
-        'config_MM':    MM,
-        'config_DD':    DD,
-        'config_parking_data': json.dumps(parking_json),
-        'config_parking_config': json.dumps(parking_config)
+    if 'application/json' in re.split(r', *', request.META['HTTP_ACCEPT']):
+        logger.info("JSON requested")
+        return JsonResponse({ 'data': parking_json, 'config': parking_config })
+    else:
+        logger.info("JSON NOT requested")
+        return render(request, 'parking/parking_plot.html', {
+            'config_date':  user_date,
+            'config_parking_id': parking_id,
+            'config_YYYY' : YYYY,
+            'config_MM':    MM,
+            'config_DD':    DD,
+            'config_parking_data': json.dumps(parking_json),
+            'config_parking_config': json.dumps(parking_config)
     })
 
 


### PR DESCRIPTION
We are on the hook to provide API access to some of our stored data. We have discussed the idea of doing something quick and easy ahead of setting up something more complex that will require database storage. 

What does everyone think of this approach, which essentially adds download capability to the existing car park graph drawing endpoint? I believe the same approach would work for Air Quality and Journey Times which are the others we've committed to.

In this case a download request is indicated by sending an 'Accept: application/json' request header; we could alternately use a new query string parameter or vary the URL (perhaps /parking/data/trumpington-park-and-ride/ in place of /parking/plot/trumpington-park-and-ride/). If we stuck with using the Accept header we might want to make use of https://github.com/fladi/django-accept-header.

We might also want to limit which properties we wanted to return since many of them are only of 'internal' significance:

```json
{
    "config": {
        "module_id": "vix",
        "module_name": "dataserver",
        "request_data": {
            "capacity": 1340,
            "feed_id": "cam_park_rss",
            "latitude": 52.1678,
            "longitude": 0.1077,
            "parking_id": "trumpington-park-and-ride",
            "parking_name": "P&R Trumpington",
            "parking_type": "park_and_ride"
        }
    },
    "data": [
        {
            "module_id": "vix",
            "module_name": "dataserver",
            "request_data": [
                {
                    "feed_id": "cam_park_rss",
                    "filename": "1525043086.427_2018-04-30-00-04-46",
                    "filepath": "2018/04/30",
                    "module_id": "park_local_rss",
                    "module_name": "feedmaker",
                    "msg_type": "feed_car_parks",
                    "parking_id": "trumpington-park-and-ride",
                    "spaces_capacity": 1340,
                    "spaces_free": 1340,
                    "spaces_occupied": 0,
                    "ts": 1525043086
                },
                ...
            ]
        }
    ]
}
```