### PR TITLE
Changes to layouts

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/base.html
+++ b/tfc_web/smartpanel/templates/smartpanel/base.html
@@ -91,6 +91,9 @@
                     <a class="mdl-navigation__link" href="{% url 'account_email' %}">Account preferences</a>
                     <a class="mdl-navigation__link" href="{% url 'account_logout' %}">Sign Out</a>
                 {% endif %}
+                    <div class="drawer-separator"></div>
+                    <a class="mdl-navigation__link" href="{% url 'smartpanel-home' %}">SmartPanels Home</a>
+                    <a class="mdl-navigation__link" href="{% url 'smartpanel-info' %}">About</a>
             </nav>
         </div>
 

--- a/tfc_web/smartpanel/templates/smartpanel/base.html
+++ b/tfc_web/smartpanel/templates/smartpanel/base.html
@@ -78,7 +78,8 @@
                     <a class="mdl-navigation__link" href="{% url 'smartpanel-layout-my' %}">My SmartPanel layouts</a>
                     <a class="mdl-navigation__link" href="{% url 'smartpanel-design' %}">New SmartPanel layout</a>
                 {% endif %}
-                    <a class="mdl-navigation__link" href="{% url 'smartpanel-layout-all' %}">SmartPanel layouts</a>
+{#                    TODO Re-enable once public opt-in done#}
+{#                    <a class="mdl-navigation__link" href="{% url 'smartpanel-layout-all' %}">SmartPanel layouts</a>#}
                 {% if user.is_authenticated %}
                     <div class="drawer-separator"></div>
                     <a class="mdl-navigation__link" href="{% url 'smartpanel-list-my-displays' %}">My SmartPanel displays</a>

--- a/tfc_web/smartpanel/templates/smartpanel/display.html
+++ b/tfc_web/smartpanel/templates/smartpanel/display.html
@@ -1,7 +1,7 @@
 {% extends "smartpanel/base.html" %}
 {% load static %}
 {% block extra_head %}
-    {{ screen_form.media }}
+    {{ display_form.media }}
     <style>
         #id_location_div_map {
             float: none !important;
@@ -10,15 +10,15 @@
 {% endblock %}
 {% block content %}
     <div>
-        <h1 class="mdl-typography--display-1-color-contrast">New Screen</h1>
-        <form action="{% if edit %}{% url 'smartpanel-edit-display' screen_form.instance.pk %}{% else %}{% url 'smartpanel-new-display' %}{% endif %}" method="post">
+        <h1 class="mdl-typography--display-1-color-contrast">New Display</h1>
+        <form action="{% if edit %}{% url 'smartpanel-edit-display' display_form.instance.pk %}{% else %}{% url 'smartpanel-new-display' %}{% endif %}" method="post">
             {% csrf_token %}
-            <p>{{ screen_form.errors }}</p>
-            {{ screen_form.as_p }}
+            <p>{{ display_form.errors }}</p>
+            {{ display_form.as_p }}
             <input class="mdl-button mdl-js-button mdl-button--raised" type="submit" value="Send">
         </form>
         {% if edit %}
-        <form action="{% url 'smartpanel-delete-display' screen_form.instance.pk %}" method="post" style="margin-top: 20px;">
+        <form action="{% url 'smartpanel-delete-display' display_form.instance.pk %}" method="post" style="margin-top: 20px;">
             {% csrf_token %}
             <input class="mdl-button mdl-js-button mdl-button--raised" type="submit" value="Delete Display">
         </form>

--- a/tfc_web/smartpanel/templates/smartpanel/displays.html
+++ b/tfc_web/smartpanel/templates/smartpanel/displays.html
@@ -12,11 +12,11 @@
     <script>
         var map = L.map('map').setView({{ mapcenter|default:"[52.205, 0.119], 13" }});
         var info_map = L.control();
-        var screens = [{% for screen in screens %}
-            { "display_url": "{% url 'smartpanel-display' screen.id %}", "layout_name": "{{ screen.layout.name }}",
-                "layout_url": "{% url 'smartpanel-layout' screen.layout.id %}",
-                "lat": "{{ screen.location.y }}", "lon": "{{ screen.location.x }}", "name": "{{ screen.name }}",
-                "edit_url": "{% url 'smartpanel-edit-display' screen.id %}"},
+        var displays = [{% for display in displays %}
+            { "display_url": "{% url 'smartpanel-display' display.id %}", "layout_name": "{{ display.layout.name }}",
+                "layout_url": "{% url 'smartpanel-layout' display.layout.id %}",
+                "lat": "{{ display.location.y }}", "lon": "{{ display.location.x }}", "name": "{{ display.name }}",
+                "edit_url": "{% url 'smartpanel-edit-display' display.id %}"},
         {% endfor %}];
 
         info_map.onAdd = function (map) {
@@ -29,13 +29,13 @@
                 attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
             info_map.addTo(map);
-            for (var i = 0; i < screens.length; i++) {
-                screens[i]['marker'] = L.marker([screens[i]['lat'], screens[i]['lon']]);
-                screens[i]['marker'].addTo(map).bindTooltip(
-                    "<a target='_blank' href='"+screens[i]['display_url']+"'>"+
-                    screens[i]['name']+"</a><br> - <a target='_blank' href='"+screens[i]['layout_url']+"'>Layout "+
-                    screens[i]['layout_name']+"</a>"+
-                    "<br> - <a target='_blank' href='"+screens[i]['edit_url']+"'>Edit display</a>",
+            for (var i = 0; i < displays.length; i++) {
+                displays[i]['marker'] = L.marker([displays[i]['lat'], displays[i]['lon']]);
+                displays[i]['marker'].addTo(map).bindTooltip(
+                    "<a target='_blank' href='"+displays[i]['display_url']+"'>"+
+                    displays[i]['name']+"</a><br> - <a target='_blank' href='"+displays[i]['layout_url']+"'>Layout "+
+                    displays[i]['layout_name']+"</a>"+
+                    "<br> - <a target='_blank' href='"+displays[i]['edit_url']+"'>Edit display</a>",
                     { permanent: true, interactive: true });
             }
         });

--- a/tfc_web/smartpanel/templates/smartpanel/home.html
+++ b/tfc_web/smartpanel/templates/smartpanel/home.html
@@ -43,24 +43,24 @@
                     </div>
                 </div>
             {% endif %}
-
-                <div class="mdl-cell mdl-cell--3-col mdl-cell--4-col-tablet mdl-cell--4-col-phone mdl-card mdl-shadow--3dp">
-                    <div class="mdl-card__media">
-                        <img src="">
-                    </div>
-                    <div class="mdl-card__title">
-                        <h4 class="mdl-card__title-text">SmartPanel layouts</h4>
-                    </div>
-                    <div class="mdl-card__supporting-text">
-                        <span class="mdl-typography--font-light mdl-typography--subhead">List of all public SmartPanel layouts</span>
-                    </div>
-                    <div class="mdl-card__actions">
-                        <a class="aqua-link mdl-button mdl-js-button mdl-typography--text-uppercase" href="{% url 'smartpanel-layout-all' %}">
-                            View
-                            <i class="material-icons">chevron_right</i>
-                        </a>
-                    </div>
-                </div>
+{# TODO Re enable once public opt-in done#}
+{#                <div class="mdl-cell mdl-cell--3-col mdl-cell--4-col-tablet mdl-cell--4-col-phone mdl-card mdl-shadow--3dp">#}
+{#                    <div class="mdl-card__media">#}
+{#                        <img src="">#}
+{#                    </div>#}
+{#                    <div class="mdl-card__title">#}
+{#                        <h4 class="mdl-card__title-text">SmartPanel layouts</h4>#}
+{#                    </div>#}
+{#                    <div class="mdl-card__supporting-text">#}
+{#                        <span class="mdl-typography--font-light mdl-typography--subhead">List of all public SmartPanel layouts</span>#}
+{#                    </div>#}
+{#                    <div class="mdl-card__actions">#}
+{#                        <a class="aqua-link mdl-button mdl-js-button mdl-typography--text-uppercase" href="{% url 'smartpanel-layout-all' %}">#}
+{#                            View#}
+{#                            <i class="material-icons">chevron_right</i>#}
+{#                        </a>#}
+{#                    </div>#}
+{#                </div>#}
 
             </div>
         </div>

--- a/tfc_web/smartpanel/templates/smartpanel/info.html
+++ b/tfc_web/smartpanel/templates/smartpanel/info.html
@@ -10,7 +10,7 @@ choices.</p>
 
 <p>These panels take advantage of the real-time processing capabilities
 of the <em>Adaptive Cities platform</em> to make up-to-the-minuite
-information available to the travelling public. Screens are geo-located
+information available to the travelling public. Displays are geo-located
 to automatically display relevant information and can be further
 customised by local managers.</p>
 

--- a/tfc_web/smartpanel/urls.py
+++ b/tfc_web/smartpanel/urls.py
@@ -17,7 +17,8 @@ urlpatterns = [
     url(r'^displays/debug/', smartpanel.displays_debug, name='smartpanel-displays-debug'),
     url(r'^design/', smartpanel.design, name='smartpanel-design'),
     url(r'^layout/my/$', smartpanel.my, name='smartpanel-layout-my'),
-    url(r'^layout/list/$', smartpanel.all, name='smartpanel-layout-all'),
+# TODO Re-enamble once opt-in option done
+#    url(r'^layout/list/$', smartpanel.all, name='smartpanel-layout-all'),
     url(r'^layout/(?P<layout_id>\d+)/config/$', smartpanel.layout_config, name='smartpanel-layout-config'),
     url(r'^layout/(?P<layout_id>\d+)/delete/$', smartpanel.layout_delete, name='smartpanel-layout-delete'),
     url(r'^layout/(?P<layout_id>\d+)/$', smartpanel.layout, name='smartpanel-layout'),

--- a/tfc_web/smartpanel/urls.py
+++ b/tfc_web/smartpanel/urls.py
@@ -1,11 +1,12 @@
 from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from smartpanel.views import smartpanel
 from smartpanel.views.widgets import weather, station_board
 
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name="smartpanel/home.html"), name='smartpanel-home'),
+    url(r'^$', login_required(TemplateView.as_view(template_name="smartpanel/home.html")), name='smartpanel-home'),
     url(r'^display/new/$', smartpanel.new_display, name='smartpanel-new-display'),
     url(r'^display/my/', smartpanel.my_displays, name='smartpanel-list-my-displays'),
     url(r'^display/(?P<display_id>\d+)/edit/', smartpanel.edit_display, name='smartpanel-edit-display'),

--- a/tfc_web/smartpanel/views/smartpanel.py
+++ b/tfc_web/smartpanel/views/smartpanel.py
@@ -140,19 +140,19 @@ def layout(request, layout_id, display=None):
 @login_required
 def new_display(request):
     if request.method == "POST":
-        screen_form = DisplayForm(request.POST)
-        if screen_form.is_valid():
-            display = screen_form.save(commit=False)
+        display_form = DisplayForm(request.POST)
+        if display_form.is_valid():
+            display = display_form.save(commit=False)
             display.owner = request.user
             display.save()
             return redirect('smartpanel-home')
     else:
-        screen_form = DisplayForm()
-    return render(request, 'smartpanel/display.html', {'screen_form': screen_form})
+        display_form = DisplayForm()
+    return render(request, 'smartpanel/display.html', {'display_form': display_form})
 
 
 def displays(request):
-    return render(request, 'smartpanel/displays.html', {'screens': Display.objects.all()})
+    return render(request, 'smartpanel/displays.html', {'displays': Display.objects.all()})
 
 
 def display_refresh(request, display_id, layout_id, version):
@@ -181,7 +181,7 @@ def displays_debug(request):
 @login_required
 def my_displays(request):
     return render(request, 'smartpanel/displays.html',
-                  {'screens': Display.objects.filter(owner=request.user), 'edit': True})
+                  {'displays': Display.objects.filter(owner=request.user), 'edit': True})
 
 
 @login_required
@@ -194,7 +194,7 @@ def edit_display(request, display_id):
             return redirect('smartpanel-home')
     else:
         display_form = DisplayForm(instance=display)
-    return render(request, 'smartpanel/display.html', {'screen_form': display_form, 'edit': True})
+    return render(request, 'smartpanel/display.html', {'display_form': display_form, 'edit': True})
 
 
 @login_required

--- a/tfc_web/smartpanel/views/smartpanel.py
+++ b/tfc_web/smartpanel/views/smartpanel.py
@@ -124,8 +124,12 @@ def layout_delete(request, layout_id):
     return redirect('smartpanel-layout-config', layout_id)
 
 
+@login_required
 def layout(request, layout_id, display=None):
-    layout = get_object_or_404(Layout, id=layout_id)
+    if request.user.is_superuser:
+        layout = get_object_or_404(Layout, id=layout_id)
+    else:
+        layout = get_object_or_404(Layout, id=layout_id, owner=request.user)
     uwl = []  # unique widget list
     for key, value in layout.design.items():
         if 'widget' in value and value['widget'] not in uwl:


### PR DESCRIPTION
This Pull Request is better reviewed commit by commit:
- Commit 41c05c1 renames some leftovers to the new terminology from "screen" to "display"
- Commit 7e2c230 hide public layouts options 
- Commit 410298d restricts access to layouts to only owners and superadmins
- Commit dc9f348 adds a couple of menu options, one principally to show smartpanels info page.
- Commit 099b741 protects the smartpanels home page to require login, otherwise it will show as an empty page. 


Part of issue #146 but not complete, will be complete when opt-in public option is implemented