### PR TITLE
Improve run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
 source /home/tfc_prod/tfc_web_venv/bin/activate
+if [[ -f /home/tfc_prod/tfc_web_envvars ]]; then
+    source /home/tfc_prod/tfc_web_envvars
+    echo 'Setting custom environmnt from /home/tfc_prod/tfc_web_envvars'
+fi
 
 cd /home/tfc_prod/tfc_web/tfc_web
 
 echo $(date) "gunicorn started " >> /var/log/tfc_prod/gunicorn.log
 
-nohup gunicorn --reload tfc_web.wsgi >/var/log/tfc_prod/gunicorn.log 2>/var/log/tfc_prod/gunicorn.err & disown
+nohup gunicorn --workers 3 --threads 3 --worker-class gthread --reload tfc_web.wsgi >/var/log/tfc_prod/gunicorn.log 2>/var/log/tfc_prod/gunicorn.err & disown
 
 
 


### PR DESCRIPTION
1) Start gunicorn with three workers each running up to three threads for
performance and also to avoid deadlocking when making API calls from within
pages also being served by gunicorn (#177)

2) Source /home/tfc_prod/tfc_web_envvars if present. One use of this is to
set DJANGO_SETTINGS_MODULE to override the default set in
tfc_web//tfc_web/tfc_web/wsgi.py which is useful when running production
servers (#166)

Closes #177, #166