### PR TITLE
Fall back to 'last known good' forecast on error

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/weather.html
+++ b/tfc_web/smartpanel/templates/smartpanel/weather.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="{% static 'smartpanel/widgets/weather/weather.css' %}">
 <body>
 
-<div style="height: calc(1080px - 60px); width: 1920px; overflow: hidden;">
+<div class="widget" style="height: calc(1080px - 60px); width: 1920px; overflow: hidden;">
 
 <div style="height: calc(2*100%/4);
             width: calc(1*100%/6);
@@ -22,6 +22,9 @@
 <h1 class="widget_error">Connection issues</h1>
 
 <h1><img src="{% static 'smartpanel/widgets/weather/weather.png' %}" alt=""> {{ location }}</h1>
+
+{% if results %}
+
 <div class="timestamp">Issued {{ issued }}</div>
 
 {% for result in results %}
@@ -53,6 +56,12 @@ Wind <b>{{ result.wind_desc }}</b> ({{ result.S }} mph) <b>{{ result.D }}</b>
 </p>
 
 {% endfor %}
+
+{% else %}
+
+<div class="timestamp">Forecast unavailable</div>
+
+{% endif %}
 
 </div>
 


### PR DESCRIPTION
The Met Office API isn't all that reliable, in particular returning
data missing documented fields. Since each forecast is valid for multiple
days it makes sense to cache a 'last known good' version when we see one
and use that if whatever we are currently fetching is broken in any way.

Note that we still cache what we fetch (or an empty place holder if we
don't fetch anything) so even in an error condition we still only
hit the API once wvery 10 minuites for each forecast location requested.