### PR TITLE
Do not delete Stop objects ever

### DIFF
--- a/tfc_web/transport/management/commands/update_bus_stops.py
+++ b/tfc_web/transport/management/commands/update_bus_stops.py
@@ -5,6 +5,8 @@ from io import BytesIO, TextIOWrapper
 from urllib.request import urlopen
 from django.db import transaction
 from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+
 from transport.models import Stop
 
 
@@ -14,7 +16,6 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = "Updates bus stops from DFT website"
 
-    @transaction.atomic
     def handle(self, **options):
         """Update Bus Stops data from the DFT website"""
         stops_csv_file = zipfile.ZipFile(BytesIO(urlopen(
@@ -26,17 +27,17 @@ class Command(BaseCommand):
         for row in csv_reader:
             csv_rows.extend([{title[i]: row[title[i]] for i in range(len(title))}])
 
-        stop_objects = []
         for element in csv_rows:
-            stop_objects.append(
-                Stop(atco_code=element['ATCOCode'],
-                     naptan_code=element['NaptanCode'],
-                     common_name=element['CommonName'],
-                     indicator=element['Indicator'],
-                     locality_name=element['LocalityName'],
-                     longitude=element['Longitude'],
-                     latitude=element['Latitude'],
-                     data=element))
-        if stop_objects:
-            Stop.objects.all().delete()
-            Stop.objects.bulk_create(stop_objects)
+            Stop.objects.update_or_create(
+                atco_code=element['ATCOCode'],
+                defaults={
+                    'naptan_code': element['NaptanCode'],
+                    'common_name': element['CommonName'],
+                    'indicator': element['Indicator'],
+                    'locality_name': element['LocalityName'],
+                    'longitude': element['Longitude'],
+                    'latitude': element['Latitude'],
+                    'data': element,
+                    'last_modified': now()
+                },
+            )


### PR DESCRIPTION
We must keep them there in case we still have buses using them in the cache, so we need to keep them at least until we update the list of routes/buses.

They could also be deleted in the future by checking the last_modified field.