### PR TITLE
Suppress journeys that terminate at the displayed stop (and rewrite 'Universal U' to 'U')

### DIFF
--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
@@ -1381,6 +1381,7 @@ function StopTimetable(widget_id) {
         name = name.replace(/Bus Station/i, 'Bus Stn');
         name = name.replace(/Cambridge North Railway Station/i, 'Cambridge Nth Stn');
         name = name.replace(/Hinchingbrooke/i, 'Hin\'brooke');
+        name = name.replace(/Universal U/i, 'U');
         return name;
     }
 

--- a/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
+++ b/tfc_web/static/smartpanel/widgets/stop_timetable/stop_timetable.js
@@ -697,6 +697,10 @@ function StopTimetable(widget_id) {
             if (journey.eta.isBefore(get_now().subtract(1, 'minutes'))) {
                 continue;
             }
+            // Skip anything that terminates here
+            if (journey.last.stop.atco_code === self.params.stop.stop_id) {
+                continue;
+            }
 
             nrows++;
 
@@ -822,6 +826,10 @@ function StopTimetable(widget_id) {
             }
             // Skip anything that left in the past
             if (journey.eta.isBefore(get_now().subtract(1, 'minutes'))) {
+                continue;
+            }
+            // Skip anything that terminates here
+            if (journey.last.stop.atco_code === self.params.stop.stop_id) {
                 continue;
             }
 


### PR DESCRIPTION
Prevent timetables listing journeys that just terminate at the stop being displayed

At the same time, rewrite line name 'Universal U' to 'U'