### PR TITLE
Fix broken links in multiple places

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/base.html
+++ b/tfc_web/smartpanel/templates/smartpanel/base.html
@@ -112,8 +112,8 @@
                 </div>
 
                 <div class="mdl-mega-footer--middle-section">
-                    <a href="http://www.gccitydeal.co.uk/citydeal/smart"><img class="footer-logo" src="{% static 'images/logo_gccd_112.png' %}"></a>
-                    <a href="http://www.connectingcambridgeshire.co.uk/smartcamb/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
+                    <a href="https://www.greatercambridge.org.uk/smart/"><img class="footer-logo" src="{% static 'images/logo_gcp_112.png' %}"></a>
+                    <a href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
                     <a href="http://www.cam.ac.uk/"><img class="footer-logo" src="{% static 'images/logo_uc_112.png' %}"></a>
                 </div>
 

--- a/tfc_web/smartpanel/templates/smartpanel/layout.html
+++ b/tfc_web/smartpanel/templates/smartpanel/layout.html
@@ -28,7 +28,7 @@
 <body>
     <div class="logos" style="height: 60px; width: {{display_width|default:"1920px"}}; position: relative;">
         <div id="screen_clock"></div>
-        <a href="http://www.connectingcambridgeshire.co.uk/smartcamb/"><img alt="Connecting Cambridgshire" src="{% static 'images/logo_sc_112.png' %}"></a>
+        <a href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/"><img alt="Connecting Cambridgshire" src="{% static 'images/logo_sc_112.png' %}"></a>
         <a href="http://www.cam.ac.uk"><img alt="The University of Cambridge" src="{% static 'images/logo_uc_112.png' %}"></a>
         <a href="https://www.greatercambridge.org.uk/"><img alt="Greater Cambridge Partnership" src="{% static 'images/logo_gcp_112.png' %}"></a>
         <span>SmartPanel</span>

--- a/tfc_web/templates/about.html
+++ b/tfc_web/templates/about.html
@@ -6,7 +6,7 @@
         <ul class="mdl-typography--font-regular mdl-typography--text">
             <li style="font-size: 16px;">Smart Cambridge programme:
                 <a class="mdl-typography--font-regular mdl-typography--text aqua-alt-link"
-                   href="http://www.connectingcambridgeshire.co.uk/smartcamb/">www.connectingcambridgeshire.co.uk/smartcamb/</a>
+                   href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/">www.connectingcambridgeshire.co.uk/smart-cambridge/</a>
             </li>
             <li style="font-size: 16px;">Smart Cambridge technology data:
                 <a href="http://smartcambridge.org"
@@ -26,7 +26,7 @@
         <ul class="mdl-typography--font-regular mdl-typography--text">
             <li style="font-size: 16px;">Call: <a href="tel:01223729079" class="aqua-alt-link">01223 729079</a></li>
             <li style="font-size: 16px;">Email: <a href="mailto:smart.cambridge@cambridgeshire.gov.uk" class="aqua-alt-link">smart.cambridge@cambridgeshire.gov.uk</a></li>
-            <li style="font-size: 16px;">Twitter: <a class="aqua-alt-link" href="http://twitter.com/smartcamb">@SmartCamb</a> <a class="aqua-alt-link" href="http://twitter.com/gccitydeal">@gccitydeal</a></li>
+            <li style="font-size: 16px;">Twitter: <a class="aqua-alt-link" href="http://twitter.com/smartcamb">@SmartCamb</a> <a class="aqua-alt-link" href="https://twitter.com/GreaterCambs">@GreaterCambs</a></li>
         </ul>
     </div>
 {% endblock %}

--- a/tfc_web/templates/base.html
+++ b/tfc_web/templates/base.html
@@ -98,8 +98,8 @@
                 </div>
 
                 <div class="mdl-mega-footer--middle-section">
-                    <a href="http://www.gccitydeal.co.uk/citydeal/smart"><img class="footer-logo" src="{% static 'images/logo_gccd_112.png' %}"></a>
-                    <a href="http://www.connectingcambridgeshire.co.uk/smartcamb/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
+                    <a href="https://www.greatercambridge.org.uk/smart/"><img class="footer-logo" src="{% static 'images/logo_gcp_112.png' %}"></a>
+                    <a href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
                     <a href="http://www.cam.ac.uk/"><img class="footer-logo" src="{% static 'images/logo_uc_112.png' %}"></a>
                 </div>
 

--- a/tfc_web/templates/index.html
+++ b/tfc_web/templates/index.html
@@ -12,7 +12,7 @@
                     will emerge.
                 </p>
                 <p>
-                <a class="mdl-typography--font-regular mdl-typography--text-uppercase aqua-alt-link" href="http://www.connectingcambridgeshire.co.uk/smartcamb/">
+                <a class="mdl-typography--font-regular mdl-typography--text-uppercase aqua-alt-link" href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/">
                     Visit Connecting Cambridgeshire website for more information&nbsp;<i class="material-icons">chevron_right</i>
                 </a>
                 </p>

--- a/tfc_web/templates/template.html
+++ b/tfc_web/templates/template.html
@@ -117,8 +117,8 @@
                     </div>
 
                     <div class="mdl-mega-footer--middle-section">
-                        <a href="http://www.gccitydeal.co.uk/citydeal/smart"><img class="footer-logo" src="{% static 'images/logo_gccd_112.png' %}"></a>
-                        <a href="http://www.connectingcambridgeshire.co.uk/smartcamb/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
+                        <a href="https://www.greatercambridge.org.uk/smart/"><img class="footer-logo" src="{% static 'images/logo_gcp_112.png' %}"></a>
+                        <a href="http://www.connectingcambridgeshire.co.uk/smart-cambridge/"><img class="footer-logo" src="{% static 'images/logo_cc_112.png' %}"></a>
                         <a href="http://www.cam.ac.uk/"><img class="footer-logo" src="{% static 'images/logo_uc_112.png' %}"></a>
                     </div>
 


### PR DESCRIPTION
Fix various external references that have rotted in various places:

1) Fix link from Connecting Cambridge and Smart Cambridge logo to  www.connectingcambridgeshire.co.uk/smartcamb/ --> www.connectingcambridgeshire.co.uk/smart-cambridge/

2) Replace CityDeal logo with GCP logo and replace link http://www.gccitydeal.co.uk/citydeal/smart --> https://www.greatercambridge.org.uk/smart/

3) Replace @gccitydeal reference with new @GreaterCambs